### PR TITLE
give value from options.unit not as string

### DIFF
--- a/dist/ng-geodist.js
+++ b/dist/ng-geodist.js
@@ -57,7 +57,7 @@ angular.module('ngGeodist', [])
       var _ref1 = parseCoordinates(end);
       var lat2 = _ref1[0];
       var lng2 = _ref1[1];
-      var earthRadius = getEarthRadius('options.unit');
+      var earthRadius = getEarthRadius(options.unit);
       var latDelta = (lat2 - lat1) * Math.PI / 180;
       var lngDelta = (lng2 - lng1) * Math.PI / 180;
       var lat1Rad = lat1 * Math.PI / 180;


### PR DESCRIPTION
so it had used just miles and ignored the options.unit value
60: var earthRadius = getEarthRadius(options.unit);
